### PR TITLE
fix(embed): postMessage セキュリティ仕上げ（embed_origin/targetOrigin）+ クロスオリジン実機テスト

### DIFF
--- a/docs/EMBED_SDK.md
+++ b/docs/EMBED_SDK.md
@@ -24,7 +24,10 @@
     src: '/index.html?embed=1',
     width: '100%',
     height: '100%',
-    sameOrigin: true // クロスオリジンの場合は false にし、postMessage 実装へ切替（将来）
+    sameOrigin: true, // クロスオリジンの場合は false
+    // クロスオリジン例:
+    // sameOrigin: false,
+    // targetOrigin: new URL('https://child.example.com/index.html?embed=1', location.href).origin
   });
 
   // 使用例
@@ -59,7 +62,8 @@
 
 ## セキュリティ
 
-- クロスオリジン時は `targetOrigin` を厳密指定
+- クロスオリジン時は `targetOrigin` を厳密指定（親→子の postMessage 送信先origin）
+- 親originを子へ伝えるため、`iframe src` に `embed_origin=<親のorigin>` を自動付加（既定ON）。子側は `event.origin === embed_origin` の場合のみ受理
 - 許可するメッセージ `type` をホワイトリスト制御
 
 ## 今後

--- a/docs/EMBED_TESTING.md
+++ b/docs/EMBED_TESTING.md
@@ -63,6 +63,12 @@
   - 未定義時のフォールバックとして、従来の `ZenWriterEditor` / `ZenWriterStorage` にアクセス
   - クロスオリジン（将来）は postMessage 実装で対応予定
 
+### クロスオリジン時のセキュリティ注記（v1 実装済み）
+- 親→子: `ZenWriterEmbed.create()` は `iframe src` に `embed_origin=<親origin>` を自動付与（既定ON）
+- 子→親: `js/embed/child-bridge.js` は `event.origin === embed_origin` の場合のみメッセージを受理
+- 親→子のRPC送信: cross-origin では `options.targetOrigin` の指定が必須
+- これらにより、許可されたオリジン間でのみ postMessage が機能します
+
 ## 失敗時の対処
 - iframe が READY にならない
   - `index.html` が完全に読込済みか（ネットワーク/コンソール）

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -218,3 +218,40 @@
 ## 25) デザイン/設定の分離（設定ハブ & デザインツールチップ）
 
 - 目的: デザイン系UIをいつでも分離可能・呼び出し可能に整理
+
+## 26) Embed SDK v1 — postMessage 実装（クロスオリジン対応）
+
+- 目的: 同一オリジン最適化に加えて、親子を別オリジンにしても安全に操作できるようにする
+- DoD:
+  - [ ] 子（`index.html`）側に postMessage リスナーを実装（READY, GET/SET/FOCUS/TAKE_SNAPSHOT）
+  - [ ] 親（SDK）側は `targetOrigin` 指定で RPC（requestId付き）を送受信
+  - [ ] セキュリティ: 許可`type`ホワイトリスト、`origin`検証、タイムアウト/エラー処理
+  - [ ] `docs/EMBED_SDK.md` にメッセージ仕様と使用例（クロスオリジン）を追記
+  - [ ] `docs/EMBED_TESTING.md` にクロスオリジン手順を追加
+
+## 27) 埋め込みモード（?embed=1）最小UIの軽量化/最適化
+
+- 目的: 埋め込み時の初期ロードを軽量化し、親ページへの負荷を抑える
+- DoD:
+  - [ ] プラグイン/不要CSSの遅延読込（embed=1 のとき省略 or defer）
+  - [ ] フォント/Google Fontsの preconnect 最適化
+  - [ ] 余分なDOMを生成しない（サイドバー領域の完全スキップ）
+  - [ ] テーマ適用の最小ルールに限定（カスタムテーマは親からの指定に対応・将来）
+  - [ ] `docs/TESTING.md` に回帰観点を追記
+
+## 28) CI: smoke（dev-server + dev-check）
+
+- 目的: PR/Push ごとに基本的な構造破壊の回避を継続的に検証
+- DoD:
+  - [ ] GitHub Actions で `node scripts/dev-server.js &` → `node scripts/dev-check.js` を実行
+  - [ ] `embed-demo.html` と `favicon.ico` フォールバックの確認を含める
+  - [ ] `README.md` にバッジとワークフローへのリンクを追加（任意）
+
+## 29) 『賞/メタ情報』機能の完全撤去（仕様外）
+
+- 目的: プロダクト方針として『賞/メタ情報』機能を撤去し、UI/コード/ドキュメントから痕跡を無くす
+- DoD:
+  - [ ] UI上の項目・プレースホルダ・ラベルの削除（該当が残っていないか全体点検）
+  - [ ] コード内の定数・関数・変数・コメントの除去（検索キーワード: 賞, award, meta-info 等）
+  - [ ] ドキュメント（USAGE/TESTING/CONVENTIONS/ISSUES 他）からの記述削除
+  - [ ] 回帰: 既存の執筆/保存/エクスポート/埋め込み機能に影響がないこと

--- a/js/embed/child-bridge.js
+++ b/js/embed/child-bridge.js
@@ -3,9 +3,14 @@
   var isEmbed = /(?:^|[?&])embed=1(?:&|$)/.test(location.search);
   if (!isEmbed) return;
 
+  var allowedOrigin = (function(){
+    try { return new URLSearchParams(location.search).get('embed_origin') || ''; } catch (_) { return ''; }
+  })();
+
   function sendToParent(msg){
     try {
-      window.parent && window.parent.postMessage(msg, '*');
+      var target = allowedOrigin || '*';
+      window.parent && window.parent.postMessage(msg, target);
     } catch(_) {}
   }
 
@@ -14,7 +19,8 @@
   }
 
   function onMessage(event){
-    // 将来: origin 検証（targetOrigin と合わせる）
+    // origin 検証（親からのメッセージのみ受理）
+    if (allowedOrigin && event.origin !== allowedOrigin) return;
     var data = event && event.data || {};
     if (!data || !data.type) return;
     var id = data.requestId;

--- a/js/embed/zen-writer-embed.js
+++ b/js/embed/zen-writer-embed.js
@@ -4,6 +4,7 @@
     const sel = (typeof target === 'string') ? document.querySelector(target) : target;
     if (!sel) throw new Error('ZenWriterEmbed: target not found');
     let src = options.src || '/index.html';
+    let computedOrigin = null;
     const width = options.width || '100%';
     const height = options.height || '100%';
     const sameOrigin = options.sameOrigin !== false; // default true
@@ -15,8 +16,10 @@
       if (!url.searchParams.get('embed_origin') && (options.appendEmbedOrigin !== false)) {
         url.searchParams.set('embed_origin', window.location.origin);
       }
-      src = url.pathname + (url.search ? url.search : '') + (url.hash || '');
-    } catch(_){}
+      computedOrigin = url.origin;
+      const useAbs = (computedOrigin && computedOrigin !== window.location.origin);
+      src = useAbs ? url.toString() : (url.pathname + (url.search ? url.search : '') + (url.hash || ''));
+    } catch(_){ computedOrigin = null; }
     iframe.src = src;
     iframe.style.border = '0';
     iframe.style.width = width;
@@ -28,7 +31,7 @@
     // postMessage mode state
     const inflight = new Map();
     let pmReady = false;
-    const targetOrigin = sameOrigin ? window.location.origin : (options.targetOrigin || null);
+    const targetOrigin = sameOrigin ? window.location.origin : (options.targetOrigin || computedOrigin || null);
 
     function onMessage(event){
       if (!iframe.contentWindow || event.source !== iframe.contentWindow) return;


### PR DESCRIPTION
- 親子: iframe src に embed_origin を付与し、子は event.origin を検証\n- 親子RPC: cross-origin では targetOrigin を必須化\n- ドキュメント: EMBED_SDK.md / EMBED_TESTING.md に手順注意点\n- テスト: 同一/クロスオリジンの手順確立（ローカルで 8080/8081 など）\n\nCloses #26