### PR TITLE
chore(dev): dev-server PORT対応 + 2ポート起動 + クロスオリジンデモ/手順 (#44)

### DIFF
--- a/docs/EMBED_TESTING.md
+++ b/docs/EMBED_TESTING.md
@@ -86,3 +86,42 @@
 ---
 更新履歴
 - v1: 初版作成（同一オリジン向け）。クロスオリジン対応は今後の postMessage 実装で追加予定。
+
+## 付録: クロスオリジン実機テスト（2ポート）
+
+同一マシンで 2 つのローカルポートを使って、親(8080) → 子(8081) のクロスオリジン挙動を確認できます。
+
+### サーバー起動
+
+- 既定の 8080 で親を起動
+  - `node scripts/dev-server.js`
+- 子側を 8081 で起動
+  - `node scripts/dev-server.js --port 8081`
+
+補足: `scripts/dev-server.js` は `PORT` 環境変数、`--port/-p` 引数、数値単独引数のいずれでもポート指定可能です。
+
+### デモページ
+
+- 親側（8080）で以下を開く
+  - `http://127.0.0.1:8080/embed-xorigin-demo.html`
+  - iframe の `src` は `http://127.0.0.1:8081/index.html?embed=1`
+  - SDK オプションは `sameOrigin:false`、`targetOrigin: 'http://127.0.0.1:8081'`
+
+### 確認ポイント
+
+- ボタン操作
+  - setContent()/getContent()/focus()/takeSnapshot() が成功すること
+- イベント
+  - 右ペインの Events に `contentChanged` / `snapshotCreated` が表示されること
+  - 入力や setContent() 実行で `contentChanged len=...` が更新されること
+- セキュリティ
+  - `embed_origin` が iframe の URL に付与される（親の origin）
+  - 子は `event.origin === embed_origin` の場合のみメッセージを受理
+  - 親→子の RPC は `targetOrigin` に 8081 を指定して送信
+
+### トラブルシュート
+
+- 8080 が既に使用中
+  - 別ターミナルで起動していないか確認、もしくは `--port 8082` などに変更
+- READY にならない
+  - 8081 側の `index.html` が正常に配信・表示されているか（ネットワーク/コンソール）

--- a/embed-xorigin-demo.html
+++ b/embed-xorigin-demo.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Zen Writer Cross-Origin Embed Demo</title>
+  <style>
+    body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Noto Sans JP, Arial, sans-serif; }
+    main { display: grid; grid-template-columns: 1fr 360px; height: 100vh; }
+    #zw-container { width: 100%; height: 100%; }
+    aside { padding: 12px; border-left: 1px solid #eee; display: grid; gap: 12px; grid-auto-rows: min-content; }
+    textarea { width: 100%; min-height: 120px; }
+    button { padding: 6px 10px; }
+    h1 { margin: 10px 12px; font-size: 18px; }
+    .note { font-size: 12px; color: #666; }
+  </style>
+</head>
+<body>
+  <h1>Zen Writer Cross-Origin Embed Demo</h1>
+  <main>
+    <div id="zw-container"></div>
+    <aside>
+      <div class="note">親(8080) → 子(8081) のクロスオリジン埋め込みデモ</div>
+      <div>
+        <label>本文を設定</label>
+        <textarea id="src-text"># Cross-Origin Test\n\nこれは 8080 親ページから 8081 の子エディターへ送信される本文です。</textarea>
+        <button id="btn-set">setContent()</button>
+      </div>
+      <div>
+        <button id="btn-get">getContent()</button>
+        <pre id="out" style="white-space: pre-wrap; background:#f7f7f7; padding:8px; height:120px; overflow:auto;"></pre>
+      </div>
+      <div>
+        <button id="btn-focus">focus()</button>
+        <button id="btn-snap">takeSnapshot()</button>
+      </div>
+      <div>
+        <strong>Events</strong>
+        <pre id="events" style="white-space: pre-wrap; background:#f7f7f7; padding:8px; height:140px; overflow:auto;"></pre>
+      </div>
+      <div class="note">targetOrigin は 8081 を使用。embed_origin は SDK が自動付与します。</div>
+    </aside>
+  </main>
+  <script src="js/embed/zen-writer-embed.js"></script>
+  <script>
+    // 親は 8080 で配信されている想定
+    const childUrl = 'http://127.0.0.1:8081/index.html?embed=1';
+    const childOrigin = new URL(childUrl, location.href).origin;
+    const sdk = ZenWriterEmbed.create('#zw-container', {
+      src: childUrl,
+      width: '100%',
+      height: '100%',
+      sameOrigin: false,
+      targetOrigin: childOrigin
+    });
+
+    const ev = document.getElementById('events');
+    function log(msg){
+      const t = new Date().toLocaleTimeString();
+      ev.textContent = `[${t}] ${msg}\n` + ev.textContent;
+    }
+    sdk.on('contentChanged', (p)=> log(`contentChanged len=${(p&&p.len)||0}`));
+    sdk.on('snapshotCreated', ()=> log('snapshotCreated'));
+
+    document.getElementById('btn-set').addEventListener('click', async () => {
+      const t = document.getElementById('src-text').value;
+      await sdk.setContent(t);
+      await sdk.focus();
+    });
+    document.getElementById('btn-get').addEventListener('click', async () => {
+      const text = await sdk.getContent();
+      document.getElementById('out').textContent = text;
+    });
+    document.getElementById('btn-focus').addEventListener('click', async () => {
+      await sdk.focus();
+    });
+    document.getElementById('btn-snap').addEventListener('click', async () => {
+      await sdk.takeSnapshot();
+      alert('スナップショットを要求しました');
+    });
+  </script>
+</body>
+</html>

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -3,7 +3,23 @@ const fs = require('fs');
 const path = require('path');
 
 const root = path.join(__dirname, '..');
-const port = 8080;
+function parsePort(){
+  const env = process.env.PORT && parseInt(process.env.PORT, 10);
+  if (!isNaN(env) && env > 0) return env;
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--port' || a === '-p') {
+      const v = parseInt(argv[i+1], 10);
+      if (!isNaN(v) && v > 0) return v;
+    }
+    const m = /^--port=(\d+)$/.exec(a);
+    if (m) return parseInt(m[1], 10);
+    if (/^\d+$/.test(a)) return parseInt(a, 10);
+  }
+  return 8080;
+}
+const port = parsePort();
 
 const mime = {
   '.html': 'text/html; charset=utf-8',

--- a/scripts/run-two-servers.js
+++ b/scripts/run-two-servers.js
@@ -1,0 +1,30 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+const serverScript = path.join(__dirname, 'dev-server.js');
+
+function start(port) {
+  const child = spawn(process.execPath, [serverScript, '--port', String(port)], {
+    env: { ...process.env, PORT: String(port) },
+    stdio: ['ignore', 'inherit', 'inherit'],
+    windowsHide: true,
+  });
+  child.on('exit', (code, signal) => {
+    console.log(`[server:${port}] exited code=${code} signal=${signal}`);
+  });
+  return child;
+}
+
+console.log('Starting two dev servers on 8080 and 8081 ...');
+const a = start(8080);
+const b = start(8081);
+
+function shutdown() {
+  console.log('\nShutting down servers...');
+  if (a && !a.killed) a.kill('SIGINT');
+  if (b && !b.killed) b.kill('SIGINT');
+  setTimeout(() => process.exit(0), 200);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);


### PR DESCRIPTION
- scripts/dev-server.js を PORT/env/CLI 引数でポート指定可能に\n- scripts/run-two-servers.js で 8080/8081 同時起動\n- embed-xorigin-demo.html を追加（親8080→子8081、sameOrigin:false + targetOrigin 指定）\n- docs/EMBED_TESTING.md に 2ポート実機テスト手順を追記\n\nCloses #44