### PR TITLE
feat: サイドバーのガジェット化 (#51)

### DIFF
--- a/docs/GADGETS.md
+++ b/docs/GADGETS.md
@@ -1,0 +1,51 @@
+# GADGETS — サイドバーのガジェット化
+
+本書は `#gadgets-panel` に小型ウィジェット（ガジェット）を配置する仕組みの設計と実装指針を示します。
+
+## 方針
+- ガジェットは小さな自己完結UI。時計/タイマー/進捗/ショートカット等を想定。
+- 初期ロード負荷を抑えるため、`?embed=1` では読み込まない（親サイトに埋め込み時は最小UIを維持）。
+- セキュリティ: DOM操作とストレージ範囲は最小限。postMessage等の外部通信は現時点では行わない。
+
+## 実装概要
+- `index.html` に `#gadgets-panel` を追加
+- 非埋め込み時のみ `js/gadgets.js` を動的ロード
+- `js/gadgets.js` は以下を提供:
+  - `ZWGadgets.register(name, factory)` でガジェットを登録
+  - `ZWGadgets.init(selector)` でコンテナへマウント（既定 `#gadgets-panel`）
+  - 例として `Clock` ガジェットを内蔵
+
+## 使い方
+```html
+<!-- index.html（抜粋） -->
+<div id="gadgets-panel" class="gadgets-panel"></div>
+<script>
+(function(){
+  var isEmbed = /(?:^|[?&])embed=1(?:&|$)/.test(location.search);
+  if (isEmbed) return;
+  function load(src){ var s=document.createElement('script'); s.src=src; s.defer=true; document.body.appendChild(s); }
+  load('js/gadgets.js');
+})();
+</script>
+```
+
+```js
+// カスタムガジェットの登録例
+ZWGadgets.register('Sample', function(el){
+  var p = document.createElement('p');
+  p.textContent = 'Hello Gadget!';
+  el.appendChild(p);
+});
+// DOM Ready 時に自動で ZWGadgets.init() が走る
+```
+
+## テスト
+- `scripts/dev-check.js` が以下を自動検証
+  - `/` のHTMLに `#gadgets-panel` が存在
+  - `/js/gadgets.js` が 200 で取得可能
+  - `/index.html?embed=1` に静的な `<script src="js/gadgets.js">` が含まれない
+
+## 将来拡張
+- ガジェット設定の保存/復元（LocalStorage）
+- 並び替え/折りたたみ
+- プラグインと同等の拡張ポイント化

--- a/index.html
+++ b/index.html
@@ -149,7 +149,6 @@
                         <input type="text" id="outline-new-levels" placeholder="部,章,節">
                         <button id="create-outline-set">作成</button>
                     </details>
-                </div>
                 <div id="outline-levels-container" class="outline-levels"></div>
                 <div id="outline-insert-buttons" class="outline-insert"></div>
             </div>
@@ -160,11 +159,15 @@
             </div>
 
             <div class="sidebar-section">
+                <h3>ガジェット</h3>
+                <div id="gadgets-panel" class="gadgets-panel" aria-label="ガジェット"></div>
+            </div>
+        </div>
+
+            <div class="sidebar-section">
                 <h3>バックアップ</h3>
                 <button id="snapshot-now">今すぐ保存</button>
                 <div id="snapshot-list" class="snapshot-list" style="margin-top:8px;"></div>
-            </div>
-
             <div class="sidebar-section">
                 <h3>ドキュメント</h3>
                 <label for="doc-select">ドキュメント一覧</label>
@@ -243,6 +246,7 @@
         load('js/themes-advanced.js');
         load('js/plugins/registry.js');
         load('js/plugins/choice.js');
+        load('js/gadgets.js');
       })();
     </script>
 </body>

--- a/js/gadgets.js
+++ b/js/gadgets.js
@@ -1,0 +1,70 @@
+(function(){
+  'use strict';
+
+  function ready(fn){
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn, { once: true });
+    else fn();
+  }
+
+  var ZWGadgets = {
+    _list: [],
+    register: function(name, factory){
+      try { this._list.push({ name: String(name||''), factory: factory }); } catch(_) {}
+    },
+    init: function(selector){
+      var sel = selector || '#gadgets-panel';
+      var root = document.querySelector(sel);
+      if (!root) return;
+      for (var i=0; i<this._list.length; i++){
+        try {
+          var g = this._list[i];
+          var wrap = document.createElement('section');
+          wrap.className = 'gadget';
+          if (g.name) {
+            var h = document.createElement('h4');
+            h.className = 'gadget-title';
+            h.textContent = g.name;
+            wrap.appendChild(h);
+          }
+          var body = document.createElement('div');
+          body.className = 'gadget-body';
+          wrap.appendChild(body);
+          if (typeof g.factory === 'function') {
+            try { g.factory(body); } catch(e){ /* ignore gadget error */ }
+          }
+          root.appendChild(wrap);
+        } catch(e) { /* ignore per gadget */ }
+      }
+    }
+  };
+
+  // expose
+  try { window.ZWGadgets = ZWGadgets; } catch(_) {}
+
+  // Default gadget: Clock
+  ZWGadgets.register('Clock', function(el){
+    try {
+      var time = document.createElement('div');
+      time.style.fontSize = '14px';
+      time.style.fontFamily = 'system-ui, -apple-system, Segoe UI, Roboto, Noto Sans JP, Arial, sans-serif';
+      el.appendChild(time);
+      function tick(){
+        try {
+          var d = new Date();
+          var z = function(n){ return (n<10?'0':'')+n };
+          var s = d.getFullYear() + '-' + z(d.getMonth()+1) + '-' + z(d.getDate()) + ' ' + z(d.getHours()) + ':' + z(d.getMinutes()) + ':' + z(d.getSeconds());
+          time.textContent = s;
+        } catch(_) {}
+      }
+      tick();
+      var id = setInterval(tick, 1000);
+      try { el.addEventListener('removed', function(){ clearInterval(id); }); } catch(_) {}
+      try { window.addEventListener('beforeunload', function(){ clearInterval(id); }, { once: true }); } catch(_) {}
+    } catch(_) {}
+  });
+
+  // auto-init when DOM ready
+  ready(function(){
+    try { ZWGadgets.init('#gadgets-panel'); } catch(_) {}
+  });
+})();

--- a/scripts/dev-check.js
+++ b/scripts/dev-check.js
@@ -46,6 +46,12 @@ function get(path) {
     const okPlugins = hasPluginsPanel && pluginRegistry.status === 200 && pluginChoice.status === 200;
     console.log('CHECK plugins ->', okPlugins ? 'OK' : 'NG', { hasPluginsPanel, registry: pluginRegistry.status, choice: pluginChoice.status });
 
+    // ガジェットの存在検証
+    const hasGadgetsPanel = /id=\"gadgets-panel\"/i.test(index.body);
+    const gadgetsJs = await get('/js/gadgets.js');
+    const okGadgets = hasGadgetsPanel && gadgetsJs.status === 200;
+    console.log('CHECK gadgets ->', okGadgets ? 'OK' : 'NG', { hasGadgetsPanel, gadgets: gadgetsJs.status });
+
     // タイトル仕様チェック（静的HTMLのベース表記 + app.js の実装確認）
     const appPath = path.join(__dirname, '..', 'js', 'app.js');
     let appSrc = '';
@@ -76,10 +82,11 @@ function get(path) {
     const eiHasApp = /<script\s+src=["']js\/app\.js["']/.test(ei);
     const eiHasChildBridge = /<script\s+src=["']js\/embed\/child-bridge\.js["']/.test(ei);
     const eiHasEmbedFlag = /setAttribute\(\'data-embed\',\'true\'\)/.test(ei);
-    const okEmbedLight = eiStatus && eiNoOutline && eiNoThemesAdv && eiNoPluginReg && eiNoPluginChoice && eiHasApp && eiHasChildBridge && eiHasEmbedFlag;
+    const eiNoGadgetsStatic = !/<script\s+src=["']js\/gadgets\.js["']/.test(ei);
+    const okEmbedLight = eiStatus && eiNoOutline && eiNoThemesAdv && eiNoPluginReg && eiNoPluginChoice && eiNoGadgetsStatic && eiHasApp && eiHasChildBridge && eiHasEmbedFlag;
     console.log('CHECK embed=1 lightweight ->', okEmbedLight ? 'OK' : 'NG', {
       status: embedIndex.status,
-      eiNoOutline, eiNoThemesAdv, eiNoPluginReg, eiNoPluginChoice, eiHasApp, eiHasChildBridge, eiHasEmbedFlag
+      eiNoOutline, eiNoThemesAdv, eiNoPluginReg, eiNoPluginChoice, eiNoGadgetsStatic, eiHasApp, eiHasChildBridge, eiHasEmbedFlag
     });
 
     // child-bridge セキュリティパターン検証
@@ -98,7 +105,7 @@ function get(path) {
     const okFav = (fav.status === 200 && /svg\+xml/.test(ct)) || (fav.status === 404); // ローカル旧プロセス時は404を許容
     console.log('GET /favicon.ico ->', fav.status, ct || '-', okFav ? 'OK' : 'NG');
 
-    if (!(okIndex && okCss && okTitleSpec && okPlugins && okEmbedDemo && okFav && okChildBridge && okEmbedLight)) {
+    if (!(okIndex && okCss && okTitleSpec && okPlugins && okGadgets && okEmbedDemo && okFav && okChildBridge && okEmbedLight)) {
       process.exit(1);
     } else {
       console.log('ALL TESTS PASSED');


### PR DESCRIPTION
Closes #51

## 概要
- サイドバーに `#gadgets-panel` を追加し、非埋め込み時のみ `js/gadgets.js` を動的ロードする仕組みを導入しました。
- `js/gadgets.js` に簡易ガジェットレジストリとデフォルトの `Clock` ガジェットを実装しました。
- `scripts/dev-check.js` にガジェット存在チェック（トップHTMLの `#gadgets-panel` と `/js/gadgets.js` 200、`?embed=1` 時の静的 `<script src="js/gadgets.js">` 不在）を追加しました。
- `docs/GADGETS.md` を追加しました（設計/使い方/テスト/将来拡張）。

## 変更点
- `index.html`: `#gadgets-panel` 追加、非埋め込み時のみ `js/gadgets.js` を動的ロード。
- `js/gadgets.js`: `ZWGadgets.register()` / `ZWGadgets.init()` 実装と `Clock` ガジェット。
- `scripts/dev-check.js`: ガジェットの存在と `embed=1` での静的gadgets不在チェックを追加。
- `docs/GADGETS.md`: 仕様ドキュメントを新規追加。

## テスト手順
1. `node scripts/dev-server.js` を起動
2. `node scripts/dev-check.js` を実行 → PASS
3. ブラウザで `/` を開き、サイドバーに "ガジェット" セクションがあり、時計が更新されることを確認
4. `/index.html?embed=1` ではガジェットが読み込まれず、最小UIのままであることを確認

## リスク / Tier
- Tier 2（中）。UIの小規模拡張。`?embed=1` ではロード抑制のため影響は限定的です。

## 関連
- Issue: #51
