### PR TITLE
feat: ガジェット設定保存/折りたたみ/並び替え (#54)

### DIFF
--- a/docs/GADGETS.md
+++ b/docs/GADGETS.md
@@ -3,11 +3,13 @@
 本書は `#gadgets-panel` に小型ウィジェット（ガジェット）を配置する仕組みの設計と実装指針を示します。
 
 ## 方針
+
 - ガジェットは小さな自己完結UI。時計/タイマー/進捗/ショートカット等を想定。
 - 初期ロード負荷を抑えるため、`?embed=1` では読み込まない（親サイトに埋め込み時は最小UIを維持）。
 - セキュリティ: DOM操作とストレージ範囲は最小限。postMessage等の外部通信は現時点では行わない。
 
 ## 実装概要
+
 - `index.html` に `#gadgets-panel` を追加
 - 非埋め込み時のみ `js/gadgets.js` を動的ロード
 - `js/gadgets.js` は以下を提供:
@@ -16,6 +18,7 @@
   - 例として `Clock` ガジェットを内蔵
 
 ## 使い方
+
 ```html
 <!-- index.html（抜粋） -->
 <div id="gadgets-panel" class="gadgets-panel"></div>
@@ -40,10 +43,37 @@ ZWGadgets.register('Sample', function(el){
 ```
 
 ## テスト
+
 - `scripts/dev-check.js` が以下を自動検証
   - `/` のHTMLに `#gadgets-panel` が存在
   - `/js/gadgets.js` が 200 で取得可能
   - `/index.html?embed=1` に静的な `<script src="js/gadgets.js">` が含まれない
+
+## 設定保存/折りたたみ/並び替え（v0.3.13+）
+
+- 仕組み
+  - LocalStorage キー: `zenWriter_gadgets:prefs`
+  - 構造: `{ order: string[], collapsed: Record<string, boolean>, settings: Record<string, any> }`
+- API
+  - `ZWGadgets.getPrefs()` / `ZWGadgets.setPrefs(prefs)`
+  - `ZWGadgets.toggle(name)` … ガジェットの開閉トグル
+  - `ZWGadgets.move(name, dir)` … 並び替え（`'up'|'down'`）
+- UI
+  - 各ガジェットのヘッダに 開閉ボタン（▼/▶）と 上下ボタン（↑/↓）を配置
+- 例
+
+```js
+// Clock を下へ移動
+ZWGadgets.move('Clock', 'down')
+
+// Clock を折りたたむ/展開
+ZWGadgets.toggle('Clock')
+
+// 直接プリファレンスを書き換えて再描画
+const prefs = ZWGadgets.getPrefs()
+prefs.order = ['Clock']
+ZWGadgets.setPrefs(prefs)
+```
 
 ## 将来拡張
 - ガジェット設定の保存/復元（LocalStorage）

--- a/js/gadgets.js
+++ b/js/gadgets.js
@@ -6,35 +6,122 @@
     else fn();
   }
 
+  var STORAGE_KEY = 'zenWriter_gadgets:prefs';
+  function loadPrefs(){
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      var p = raw ? JSON.parse(raw) : null;
+      if (!p || typeof p !== 'object') p = { order: [], collapsed: {}, settings: {} };
+      if (!Array.isArray(p.order)) p.order = [];
+      if (!p.collapsed || typeof p.collapsed !== 'object') p.collapsed = {};
+      if (!p.settings || typeof p.settings !== 'object') p.settings = {};
+      return p;
+    } catch(_) { return { order: [], collapsed: {}, settings: {} }; }
+  }
+  function savePrefs(p){
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(p||{})); } catch(_) {}
+  }
+
   var ZWGadgets = {
     _list: [],
     register: function(name, factory){
       try { this._list.push({ name: String(name||''), factory: factory }); } catch(_) {}
     },
+    getPrefs: function(){ return loadPrefs(); },
+    setPrefs: function(p){ savePrefs(p||{ order: [], collapsed: {}, settings: {} }); try { this._renderLast && this._renderLast(); } catch(_) {} },
+    move: function(name, dir){
+      try {
+        var p = loadPrefs();
+        var names = this._list.map(function(x){ return x.name||''; });
+        // build effective order
+        var eff = [];
+        for (var i=0;i<p.order.length;i++){ if (names.indexOf(p.order[i])>=0 && eff.indexOf(p.order[i])<0) eff.push(p.order[i]); }
+        for (var j=0;j<names.length;j++){ if (eff.indexOf(names[j])<0) eff.push(names[j]); }
+        var idx = eff.indexOf(name);
+        if (idx<0) return;
+        if (dir==='up' && idx>0){ var t=eff[idx-1]; eff[idx-1]=eff[idx]; eff[idx]=t; }
+        if (dir==='down' && idx<eff.length-1){ var t2=eff[idx+1]; eff[idx+1]=eff[idx]; eff[idx]=t2; }
+        p.order = eff;
+        savePrefs(p);
+        try { this._renderLast && this._renderLast(); } catch(_) {}
+      } catch(_) {}
+    },
+    toggle: function(name){
+      try {
+        var p = loadPrefs();
+        p.collapsed = p.collapsed || {};
+        p.collapsed[name] = !p.collapsed[name];
+        savePrefs(p);
+        try { this._renderLast && this._renderLast(); } catch(_) {}
+      } catch(_) {}
+    },
     init: function(selector){
+      var self = this;
       var sel = selector || '#gadgets-panel';
       var root = document.querySelector(sel);
       if (!root) return;
-      for (var i=0; i<this._list.length; i++){
-        try {
-          var g = this._list[i];
-          var wrap = document.createElement('section');
-          wrap.className = 'gadget';
-          if (g.name) {
-            var h = document.createElement('h4');
-            h.className = 'gadget-title';
-            h.textContent = g.name;
-            wrap.appendChild(h);
-          }
-          var body = document.createElement('div');
-          body.className = 'gadget-body';
-          wrap.appendChild(body);
-          if (typeof g.factory === 'function') {
-            try { g.factory(body); } catch(e){ /* ignore gadget error */ }
-          }
-          root.appendChild(wrap);
-        } catch(e) { /* ignore per gadget */ }
+
+      function buildOrder(){
+        var p = loadPrefs();
+        var names = self._list.map(function(x){ return x.name||''; });
+        var eff = [];
+        for (var i=0;i<p.order.length;i++){ if (names.indexOf(p.order[i])>=0 && eff.indexOf(p.order[i])<0) eff.push(p.order[i]); }
+        for (var j=0;j<names.length;j++){ if (eff.indexOf(names[j])<0) eff.push(names[j]); }
+        return { order: eff, prefs: p };
       }
+
+      function render(){
+        var state = buildOrder();
+        var order = state.order, prefs = state.prefs;
+        // clear
+        while (root.firstChild) root.removeChild(root.firstChild);
+        // render all
+        for (var k=0; k<order.length; k++){
+          var name = order[k];
+          var g = null;
+          for (var t=0; t<self._list.length; t++){ if ((self._list[t].name||'')===name){ g=self._list[t]; break; } }
+          if (!g) continue;
+          try {
+            var wrap = document.createElement('section');
+            wrap.className = 'gadget';
+
+            var head = document.createElement('div');
+            head.className = 'gadget-head';
+            var toggleBtn = document.createElement('button'); toggleBtn.type='button'; toggleBtn.className='gadget-toggle'; toggleBtn.textContent = (prefs.collapsed[name] ? '▶' : '▼');
+            var title = document.createElement('h4'); title.className='gadget-title'; title.textContent = name;
+            var upBtn = document.createElement('button'); upBtn.type='button'; upBtn.className='gadget-move-up small'; upBtn.textContent='↑'; upBtn.title='上へ';
+            var downBtn = document.createElement('button'); downBtn.type='button'; downBtn.className='gadget-move-down small'; downBtn.textContent='↓'; downBtn.title='下へ';
+            head.appendChild(toggleBtn); head.appendChild(title); head.appendChild(upBtn); head.appendChild(downBtn);
+            head.style.display='flex'; head.style.alignItems='center'; head.style.gap='6px'; head.style.marginBottom='4px';
+            wrap.appendChild(head);
+
+            var body = document.createElement('div');
+            body.className = 'gadget-body';
+            if (prefs.collapsed[name]) body.style.display = 'none';
+            wrap.appendChild(body);
+            if (typeof g.factory === 'function') {
+              try { g.factory(body); } catch(e){ /* ignore gadget error */ }
+            }
+
+            // events
+            toggleBtn.addEventListener('click', function(n, b, btn){ return function(){
+              try {
+                var p = loadPrefs(); p.collapsed = p.collapsed||{}; p.collapsed[n] = !p.collapsed[n]; savePrefs(p);
+                btn.textContent = (p.collapsed[n] ? '▶' : '▼');
+                b.style.display = p.collapsed[n] ? 'none' : '';
+              } catch(_) {}
+            }; }(name, body, toggleBtn));
+
+            upBtn.addEventListener('click', function(n){ return function(){ self.move(n, 'up'); }; }(name));
+            downBtn.addEventListener('click', function(n){ return function(){ self.move(n, 'down'); }; }(name));
+
+            root.appendChild(wrap);
+          } catch(e) { /* ignore per gadget */ }
+        }
+      }
+
+      self._renderLast = render;
+      render();
     }
   };
 

--- a/scripts/dev-check.js
+++ b/scripts/dev-check.js
@@ -52,6 +52,18 @@ function get(path) {
     const okGadgets = hasGadgetsPanel && gadgetsJs.status === 200;
     console.log('CHECK gadgets ->', okGadgets ? 'OK' : 'NG', { hasGadgetsPanel, gadgets: gadgetsJs.status });
 
+    // ガジェットPrefs APIの静的実装確認（js/gadgets.js を読み取り）
+    const gadgetsPath = path.join(__dirname, '..', 'js', 'gadgets.js');
+    let gadgetsSrc = '';
+    try { gadgetsSrc = fs.readFileSync(gadgetsPath, 'utf-8'); } catch(e) { console.error('READ FAIL:', gadgetsPath, e.message); }
+    const hasStorageKey = /STORAGE_KEY\s*=\s*['\"]zenWriter_gadgets:prefs['\"]/m.test(gadgetsSrc);
+    const hasGetPrefs = /getPrefs\s*:\s*function\s*\(/m.test(gadgetsSrc);
+    const hasSetPrefs = /setPrefs\s*:\s*function\s*\(/m.test(gadgetsSrc);
+    const hasMove = /move\s*:\s*function\s*\(name,\s*dir\)/m.test(gadgetsSrc);
+    const hasToggle = /toggle\s*:\s*function\s*\(/m.test(gadgetsSrc);
+    const okGadgetsApi = hasStorageKey && hasGetPrefs && hasSetPrefs && hasMove && hasToggle;
+    console.log('CHECK gadgets API (static) ->', okGadgetsApi ? 'OK' : 'NG', { hasStorageKey, hasGetPrefs, hasSetPrefs, hasMove, hasToggle });
+
     // タイトル仕様チェック（静的HTMLのベース表記 + app.js の実装確認）
     const appPath = path.join(__dirname, '..', 'js', 'app.js');
     let appSrc = '';
@@ -105,7 +117,7 @@ function get(path) {
     const okFav = (fav.status === 200 && /svg\+xml/.test(ct)) || (fav.status === 404); // ローカル旧プロセス時は404を許容
     console.log('GET /favicon.ico ->', fav.status, ct || '-', okFav ? 'OK' : 'NG');
 
-    if (!(okIndex && okCss && okTitleSpec && okPlugins && okGadgets && okEmbedDemo && okFav && okChildBridge && okEmbedLight)) {
+    if (!(okIndex && okCss && okTitleSpec && okPlugins && okGadgets && okGadgetsApi && okEmbedDemo && okFav && okChildBridge && okEmbedLight)) {
       process.exit(1);
     } else {
       console.log('ALL TESTS PASSED');


### PR DESCRIPTION
## 概要
- ガジェットの設定保存/折りたたみ/並び替えを追加しました。
  - LocalStorage キー: `zenWriter_gadgets:prefs` （`order`/`collapsed`/`settings`）
  - API: `ZWGadgets.getPrefs/setPrefs/toggle/move`
  - UI: 各ガジェットに開閉（▼/▶）と上下（↑/↓）ボタン
- `scripts/dev-check.js` にガジェットPrefs APIの静的検証を追加
- `docs/GADGETS.md` に使い方を追記

## 変更点
- `js/gadgets.js`: prefs の保存/復元、開閉トグル、上下移動、再描画
- `scripts/dev-check.js`: `zenWriter_gadgets:prefs` と API 実装の静的チェック
- `docs/GADGETS.md`: 設定保存/折りたたみ/並び替えの説明を追加

## テスト手順
1. `node scripts/dev-server.js` を起動
2. `node scripts/dev-check.js` → PASS（gadgets API static check を含む）
3. ブラウザで `/` を開き、ガジェットの▼/▶/↑/↓ が動作し、リロード後も状態が維持されること
4. `/index.html?embed=1` ではガジェットがロードされず、最小UIのままであること

## リスク / Tier
- Tier 2（中）。LocalStorage 書き込みを伴うUI変更だが、後方互換のためキーを新設。

## 関連
- Issue: #54
