### PR TITLE
feat: Mission 5 ガジェット操作の高度化（DnD + 設定UI） (#59)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -392,11 +392,20 @@ input[type="color"] {
 /* ===== ガジェット（サイドバー） ===== */
 .gadgets-panel { display: block; }
 .gadget { border: 1px solid var(--border-color); border-radius: 6px; padding: 6px 8px; background: var(--bg-color); margin-bottom: 10px; }
-.gadget-head { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
+.gadget-head { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; cursor: grab; }
+.gadget-head:active { cursor: grabbing; }
 .gadget-title { font-size: 0.95rem; font-weight: 600; margin: 0; }
 .gadget-toggle { background: transparent; color: inherit; border: 1px solid var(--border-color); padding: 2px 6px; border-radius: 4px; }
 .gadget-move-up, .gadget-move-down { background: transparent; color: inherit; border: 1px solid var(--border-color); padding: 2px 6px; border-radius: 4px; }
 .gadget-clock { font-size: 14px; font-family: system-ui, -apple-system, Segoe UI, Roboto, 'Noto Sans JP', Arial, sans-serif; }
+
+/* 設定UI */
+.gadget-settings-btn { background: transparent; color: inherit; border: 1px solid var(--border-color); padding: 2px 6px; border-radius: 4px; }
+.gadget-settings { margin-top: 6px; padding: 6px 8px; border-top: 1px dashed var(--border-color); background: rgba(0,0,0,0.03); }
+
+/* ドラッグ状態 */
+.gadget.is-dragging { opacity: 0.6; }
+.gadget.drag-over { outline: 2px dashed var(--focus-color); outline-offset: 2px; }
 
 /* ===== ミニHUD ===== */
 .mini-hud {

--- a/docs/GADGETS.md
+++ b/docs/GADGETS.md
@@ -88,3 +88,69 @@ ZWGadgets.setPrefs(prefs)
 3. 「↑」「↓」で順序が変わること（Clock が上下に移動）
 4. ページをリロードし、開閉状態と順序が保持されていること
 5. `?embed=1` ではガジェットが表示されないことを確認
+
+## ドラッグ＆ドロップ並び替え（Mission 5）
+
+- サイドバーの各ガジェットはヘッダ（タイトル行）をドラッグして並び替えが可能です。
+- フォールバックとして従来の「↑/↓」ボタンも維持しています（キーボード操作向け）。
+
+### 備考
+
+- 内部的には `dataTransfer.setData('text/gadget-name', <name>)` を用い、`drop` 時に順序配列（prefs.order）を更新します。
+
+## 設定UIフレームワーク（Mission 5）
+
+- ガジェットごとに設定パネルを提供できます。登録 API は以下です。
+
+```js
+// 設定UIの登録（ガジェット名ごと）
+ZWGadgets.registerSettings('Sample', function(panelEl, ctx){
+  const enable = document.createElement('input');
+  enable.type = 'checkbox';
+  enable.checked = !!ctx.get('enabled', false);
+  enable.addEventListener('change', () => ctx.set('enabled', !!enable.checked));
+  panelEl.appendChild(enable);
+});
+```
+
+- ガジェット本体の factory には `api` が渡されます。
+
+```js
+ZWGadgets.register('Sample', function(el, api){
+  const enabled = api.get('enabled', false);
+  // ...
+});
+```
+
+### 提供されるコンテキスト API
+
+- factory の第2引数 `api`、および settings の第2引数 `ctx` は以下を持ちます。
+  - `get(key, default)` 設定値の取得
+  - `set(key, value)` 設定値の保存（保存後は自動で再描画）
+  - `prefs()` 現在のプリファレンスオブジェクト取得
+  - `refresh()` 明示的な再描画要求
+
+### 例: Clock の 12/24 時間表示
+
+```js
+// 表示ロジック（抜粋）
+const hour24 = api.get('hour24', true);
+```
+
+設定UI:
+
+```js
+ZWGadgets.registerSettings('Clock', function(el, ctx){
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.checked = !!ctx.get('hour24', true);
+  cb.addEventListener('change', () => ctx.set('hour24', !!cb.checked));
+  el.appendChild(cb);
+});
+```
+
+## テスト（追加事項）
+
+- `scripts/dev-check.js` は次を静的に検証します。
+  - DnD: `draggable=true`、`dataTransfer.setData('text/gadget-name', ...)`、`drop` リスナーの存在
+  - 設定UI: `registerSettings/getSettings/setSetting` の存在

--- a/js/gadgets.js
+++ b/js/gadgets.js
@@ -24,11 +24,26 @@
 
   var ZWGadgets = {
     _list: [],
+    _settings: {},
     register: function(name, factory){
       try { this._list.push({ name: String(name||''), factory: factory }); } catch(_) {}
     },
+    registerSettings: function(name, factory){
+      try { this._settings[String(name||'')] = factory; } catch(_) {}
+    },
     getPrefs: function(){ return loadPrefs(); },
     setPrefs: function(p){ savePrefs(p||{ order: [], collapsed: {}, settings: {} }); try { this._renderLast && this._renderLast(); } catch(_) {} },
+    getSettings: function(name){ try { var p = loadPrefs(); return (p.settings && p.settings[name]) || {}; } catch(_) { return {}; } },
+    setSetting: function(name, key, value){
+      try {
+        var p = loadPrefs();
+        p.settings = p.settings || {};
+        var s = p.settings[name] = p.settings[name] || {};
+        s[key] = value;
+        savePrefs(p);
+        try { this._renderLast && this._renderLast(); } catch(_) {}
+      } catch(_) {}
+    },
     move: function(name, dir){
       try {
         var p = loadPrefs();
@@ -84,6 +99,8 @@
           try {
             var wrap = document.createElement('section');
             wrap.className = 'gadget';
+            wrap.dataset.name = name;
+            wrap.setAttribute('draggable', 'true');
 
             var head = document.createElement('div');
             head.className = 'gadget-head';
@@ -91,7 +108,14 @@
             var title = document.createElement('h4'); title.className='gadget-title'; title.textContent = name;
             var upBtn = document.createElement('button'); upBtn.type='button'; upBtn.className='gadget-move-up small'; upBtn.textContent='↑'; upBtn.title='上へ';
             var downBtn = document.createElement('button'); downBtn.type='button'; downBtn.className='gadget-move-down small'; downBtn.textContent='↓'; downBtn.title='下へ';
-            head.appendChild(toggleBtn); head.appendChild(title); head.appendChild(upBtn); head.appendChild(downBtn);
+            var settingsBtn = null;
+            if (self._settings[name]){
+              settingsBtn = document.createElement('button');
+              settingsBtn.type='button'; settingsBtn.className='gadget-settings-btn small'; settingsBtn.title='設定'; settingsBtn.textContent='⚙';
+            }
+            head.appendChild(toggleBtn); head.appendChild(title);
+            if (settingsBtn) head.appendChild(settingsBtn);
+            head.appendChild(upBtn); head.appendChild(downBtn);
             // styles moved to CSS (.gadget-head)
             wrap.appendChild(head);
 
@@ -100,7 +124,15 @@
             if (prefs.collapsed[name]) body.style.display = 'none';
             wrap.appendChild(body);
             if (typeof g.factory === 'function') {
-              try { g.factory(body); } catch(e){ /* ignore gadget error */ }
+              try {
+                var api = {
+                  get: function(key, d){ var s = self.getSettings(name); return (key in s) ? s[key] : d; },
+                  set: function(key, val){ self.setSetting(name, key, val); },
+                  prefs: function(){ return self.getPrefs(); },
+                  refresh: function(){ try { self._renderLast && self._renderLast(); } catch(_) {} }
+                };
+                g.factory(body, api);
+              } catch(e){ /* ignore gadget error */ }
             }
 
             // events
@@ -114,6 +146,58 @@
 
             upBtn.addEventListener('click', function(n){ return function(){ self.move(n, 'up'); }; }(name));
             downBtn.addEventListener('click', function(n){ return function(){ self.move(n, 'down'); }; }(name));
+
+            // settings panel
+            if (settingsBtn){
+              var panel = document.createElement('div'); panel.className='gadget-settings'; panel.style.display='none';
+              wrap.appendChild(panel);
+              settingsBtn.addEventListener('click', function(n, p, btn){ return function(){
+                try {
+                  var visible = p.style.display !== 'none';
+                  p.style.display = visible ? 'none' : '';
+                  if (!visible){
+                    // render settings lazily
+                    try {
+                      p.innerHTML = '';
+                      var sApi = {
+                        get: function(key, d){ var s = self.getSettings(n); return (key in s) ? s[key] : d; },
+                        set: function(key, val){ self.setSetting(n, key, val); },
+                        prefs: function(){ return self.getPrefs(); },
+                        refresh: function(){ try { self._renderLast && self._renderLast(); } catch(_) {} }
+                      };
+                      self._settings[n](p, sApi);
+                    } catch(_) {}
+                  }
+                } catch(_) {}
+              }; }(name, panel, settingsBtn));
+            }
+
+            // drag and drop reorder
+            wrap.addEventListener('dragstart', function(ev){ try { wrap.classList.add('is-dragging'); ev.dataTransfer.setData('text/gadget-name', name); ev.dataTransfer.effectAllowed='move'; } catch(_) {} });
+            wrap.addEventListener('dragend', function(){ try { wrap.classList.remove('is-dragging'); } catch(_) {} });
+            wrap.addEventListener('dragover', function(ev){ try { ev.preventDefault(); ev.dataTransfer.dropEffect='move'; wrap.classList.add('drag-over'); } catch(_) {} });
+            wrap.addEventListener('dragleave', function(){ try { wrap.classList.remove('drag-over'); } catch(_) {} });
+            wrap.addEventListener('drop', function(ev){
+              try {
+                ev.preventDefault();
+                wrap.classList.remove('drag-over');
+                var src = ev.dataTransfer.getData('text/gadget-name');
+                var dst = name;
+                if (!src || !dst || src===dst) return;
+                var p = loadPrefs();
+                var names = self._list.map(function(x){ return x.name||''; });
+                var eff = [];
+                for (var i=0;i<p.order.length;i++){ if (names.indexOf(p.order[i])>=0 && eff.indexOf(p.order[i])<0) eff.push(p.order[i]); }
+                for (var j=0;j<names.length;j++){ if (eff.indexOf(names[j])<0) eff.push(names[j]); }
+                var sIdx = eff.indexOf(src), dIdx = eff.indexOf(dst);
+                if (sIdx<0 || dIdx<0) return;
+                // move src before dst
+                eff.splice(dIdx, 0, eff.splice(sIdx,1)[0]);
+                p.order = eff;
+                savePrefs(p);
+                try { self._renderLast && self._renderLast(); } catch(_) {}
+              } catch(_) {}
+            });
 
             root.appendChild(wrap);
           } catch(e) { /* ignore per gadget */ }
@@ -129,7 +213,7 @@
   try { window.ZWGadgets = ZWGadgets; } catch(_) {}
 
   // Default gadget: Clock
-  ZWGadgets.register('Clock', function(el){
+  ZWGadgets.register('Clock', function(el, api){
     try {
       var time = document.createElement('div');
       time.className = 'gadget-clock';
@@ -138,7 +222,11 @@
         try {
           var d = new Date();
           var z = function(n){ return (n<10?'0':'')+n };
-          var s = d.getFullYear() + '-' + z(d.getMonth()+1) + '-' + z(d.getDate()) + ' ' + z(d.getHours()) + ':' + z(d.getMinutes()) + ':' + z(d.getSeconds());
+          var hour24 = api && typeof api.get==='function' ? !!api.get('hour24', true) : true;
+          var h = d.getHours();
+          var ap = '';
+          if (!hour24){ ap = (h>=12?' PM':' AM'); h = h%12; if (h===0) h = 12; }
+          var s = d.getFullYear() + '-' + z(d.getMonth()+1) + '-' + z(d.getDate()) + ' ' + (hour24? z(h) : (h<10?' '+h:h)) + ':' + z(d.getMinutes()) + ':' + z(d.getSeconds()) + (hour24?'':ap);
           time.textContent = s;
         } catch(_) {}
       }
@@ -146,6 +234,18 @@
       var id = setInterval(tick, 1000);
       try { el.addEventListener('removed', function(){ clearInterval(id); }); } catch(_) {}
       try { window.addEventListener('beforeunload', function(){ clearInterval(id); }, { once: true }); } catch(_) {}
+    } catch(_) {}
+  });
+
+  // Clock settings UI
+  ZWGadgets.registerSettings('Clock', function(el, ctx){
+    try {
+      var row = document.createElement('label'); row.style.display='flex'; row.style.alignItems='center'; row.style.gap='6px';
+      var cb = document.createElement('input'); cb.type='checkbox'; cb.checked = !!ctx.get('hour24', true);
+      var txt = document.createElement('span'); txt.textContent = '24時間表示';
+      cb.addEventListener('change', function(){ try { ctx.set('hour24', !!cb.checked); } catch(_) {} });
+      row.appendChild(cb); row.appendChild(txt);
+      el.appendChild(row);
     } catch(_) {}
   });
 

--- a/scripts/dev-check.js
+++ b/scripts/dev-check.js
@@ -36,7 +36,10 @@ function get(path) {
     const hasRootShowPadding = /html:not\(\[data-toolbar-hidden=\"true\"\]\) #editor/.test(css.body);
     const removedBodyRule = !/body:not\(\.toolbar-hidden\) #editor/.test(css.body);
     const hasProgressCss = /\.goal-progress__bar/.test(css.body);
-    const okCss = css.status === 200 && hasRootHide && hasRootShowPadding && removedBodyRule && hasProgressCss;
+    const hasCssSettingsBtn = /\.gadget-settings-btn\b/.test(css.body || '');
+    const hasCssSettings = /\.gadget-settings\b/.test(css.body || '');
+    const hasCssDrag = /\.gadget\.is-dragging\b/.test(css.body || '') && /\.gadget\.drag-over\b/.test(css.body || '');
+    const okCss = css.status === 200 && hasRootHide && hasRootShowPadding && removedBodyRule && hasProgressCss && hasCssSettingsBtn && hasCssSettings && hasCssDrag;
     console.log('GET /css/style.css ->', css.status, okCss ? 'OK' : 'NG');
 
     // プラグインUIとスクリプトの存在検証
@@ -61,8 +64,16 @@ function get(path) {
     const hasSetPrefs = /setPrefs\s*:\s*function\s*\(/m.test(gadgetsSrc);
     const hasMove = /move\s*:\s*function\s*\(name,\s*dir\)/m.test(gadgetsSrc);
     const hasToggle = /toggle\s*:\s*function\s*\(/m.test(gadgetsSrc);
+    const hasRegisterSettings = /registerSettings\s*:\s*function\s*\(name,\s*factory\)/m.test(gadgetsSrc);
+    const hasGetSettings = /getSettings\s*:\s*function\s*\(name\)/m.test(gadgetsSrc);
+    const hasSetSetting = /setSetting\s*:\s*function\s*\(name,\s*key,\s*value\)/m.test(gadgetsSrc);
+    const hasDraggable = /setAttribute\(\s*['\"]draggable['\"],\s*['\"]true['\"]\s*\)/m.test(gadgetsSrc);
+    const hasDnDData = /dataTransfer\.setData\(\s*['\"]text\/gadget-name['\"],/m.test(gadgetsSrc);
+    const hasDropListener = /addEventListener\(\s*['\"]drop['\"]/m.test(gadgetsSrc);
     const okGadgetsApi = hasStorageKey && hasGetPrefs && hasSetPrefs && hasMove && hasToggle;
+    const okGadgetsM5 = hasRegisterSettings && hasGetSettings && hasSetSetting && hasDraggable && hasDnDData && hasDropListener;
     console.log('CHECK gadgets API (static) ->', okGadgetsApi ? 'OK' : 'NG', { hasStorageKey, hasGetPrefs, hasSetPrefs, hasMove, hasToggle });
+    console.log('CHECK gadgets M5 (static) ->', okGadgetsM5 ? 'OK' : 'NG', { hasRegisterSettings, hasGetSettings, hasSetSetting, hasDraggable, hasDnDData, hasDropListener });
 
     // タイトル仕様チェック（静的HTMLのベース表記 + app.js の実装確認）
     const appPath = path.join(__dirname, '..', 'js', 'app.js');
@@ -117,7 +128,7 @@ function get(path) {
     const okFav = (fav.status === 200 && /svg\+xml/.test(ct)) || (fav.status === 404); // ローカル旧プロセス時は404を許容
     console.log('GET /favicon.ico ->', fav.status, ct || '-', okFav ? 'OK' : 'NG');
 
-    if (!(okIndex && okCss && okTitleSpec && okPlugins && okGadgets && okGadgetsApi && okEmbedDemo && okFav && okChildBridge && okEmbedLight)) {
+    if (!(okIndex && okCss && okTitleSpec && okPlugins && okGadgets && okGadgetsApi && okGadgetsM5 && okEmbedDemo && okFav && okChildBridge && okEmbedLight)) {
       process.exit(1);
     } else {
       console.log('ALL TESTS PASSED');


### PR DESCRIPTION
## Mission 5: ガジェット操作の高度化（DnD + 設定UI）

### 変更概要
- DnD 並び替え（ヘッダをドラッグ、`prefs.order` へ保存）
- 設定UIフレームワーク追加
  - API: `registerSettings/getSettings/setSetting`
  - ガジェット factory に `api`（get/set/prefs/refresh）を注入
- Clock ガジェットに 12/24 時間表示切替（設定UI付き）
- CSS: 設定ボタン/パネルとドラッグ状態のスタイルを追加
- DevCheck: 新APIとDnDの静的検証を追加
- Docs: `docs/GADGETS.md` に DnD/設定UI の使い方と例を追記

### テスト
- `node scripts/dev-server.js` → `node scripts/dev-check.js` で PASS

### 関連
- Closes #59
