### PR TITLE
docs: Mission 10 — DocFXドキュメントサイト構築

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "docfx": {
+      "version": "2.78.3",
+      "commands": [
+        "docfx"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,8 +1,17 @@
-name: Deploy static site to Pages
+name: Docs — Build & Deploy (DocFX)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
+    paths:
+      - "docfx.json"
+      - "toc.yml"
+      - "README.md"
+      - "AI_CONTEXT.md"
+      - "docs/**"
+      - "docs/**.md"
+      - "docs/**/toc.yml"
+      - ".github/workflows/deploy-pages.yml"
   workflow_dispatch:
 
 permissions:
@@ -18,20 +27,31 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore DocFX tool
+        run: dotnet tool restore
+
+      - name: Build DocFX site
+        run: dotnet docfx build
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: '.'
+          path: "_site"
+
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ tmp/
 scripts/gh-*.ps1
 shared-workflows/
 
+# DocFX build outputs
+_site/
+.docfx/
+
 # Playwright outputs
 test-results/
 playwright-report/

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -2,71 +2,75 @@
 
 この文書は、エージェント/開発者が作業を中断/再開する際に必要な前提情報をコンパクトに提供します。
 
-- 最終更新: 2025-10-09T13:32:00+09:00
-- 現在のミッション: Mission 9: ガジェットE2Eテスト拡張
-- ブランチ: feature/m9-e2e-gadgets
-- 関連: Issue なし, PR 未作成
-- 進捗: 80% / ステータス: コミット準備（E2E安定化済み）
-- 次の中断可能点: PR 作成 → CI 成功 を確認した時点
+- 最終更新: 2025-10-09T14:48:00+09:00
+- 現在のミッション: Mission 10: DocFXドキュメントサイト構築
+- ブランチ: feature/m10-docfx
+- 関連: Issue #78 (technical-debt)
+- 進捗: 10% / ステータス: DocFX 初期設定・CI準備中
+- 次の中断可能点: DocFX build 成功・GitHub Pages workflow 確認時
 
 ## 決定事項
 
 - 全プロジェクトで「複合ミッション・ワークフロー」と「CI 連携マージ」を採用
 - リポジトリ直下で AI_CONTEXT.md を維持し、作業の区切りで更新
 - E2E は Playwright を採用。`scripts/run-two-servers.js` を webServer で起動し、同一/クロスオリジンを自動検証する
-- Mission 9 では sidebar の開閉とアニメーションをテスト中に制御する暫定措置を採用（将来 Issue 化してユーザー操作準拠へ改善）
+- Mission 9 では sidebar の開閉とアニメーションをテスト中に制御する暫定措置を採用（Issue #78 でフォローアップ）
+- Mission 10 では DocFX を用いたドキュメントサイト構築と GitHub Pages 自動デプロイを実装する
 
 ## リポジトリ構成（中央ワークフロー採用）
+
 - 共有リポジトリ: `YuShimoji/shared-workflows`
   - 目的: 再利用可能な GitHub Actions ワークフローを提供
   - 参照タグ: `v0.1.0`
   - 提供ワークフロー:
     - `.github/workflows/ci-smoke.yml`（workflow_call）
-    - `.github/workflows/sync-issues.yml`（workflow_call）
-- 本リポジトリ: `YuShimoji/WritingPage`
-  - `.github/workflows/ci-smoke.yml` → 共有版を `uses: ...@v0.1.0` で呼び出すラッパー
-  - `.github/workflows/sync-issues.yml` → 同上
 
 ## ブランチ戦略
+
 - `main`: 安定ブランチ。PRは基本 Squash Merge。
 - `develop`: 統合ブランチ。`feat/**`, `chore/**`, `docs/**`, `fix/**` からの集約。
 - 命名規則: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`, `docs/<topic>`。
 
 ## CI/Sync 運用
+
 - CI Smoke: push（`main`, `develop`, `feat/**`）、pull_request、workflow_dispatch で起動。
 - Sync Issues: `docs/ISSUES.md` 変更で起動、または手動実行。
 - 共有ワークフローは `secrets: inherit` で呼び出し。
 
 ## ローカル検証
+
 - 開発サーバー: `node scripts/dev-server.js`（PORT 可変: `--port` / `-p` / `PORT`）
 - 2ポート同時起動: `node scripts/run-two-servers.js`（8080/8081）
 - スモークテスト: `node scripts/dev-check.js` → `ALL TESTS PASSED` を確認
 - クロスオリジン検証手順: `docs/EMBED_TESTING.md`（v1.1 付録参照）
 
 ## 自律的再開プロトコル（チェックリスト）
-1) 状況把握
+
+1. 状況把握
    - `git status -sb` で未コミット/見慣れないブランチ有無を確認
    - ワークフローが共有版を参照しているか（`uses: YuShimoji/shared-workflows/...@v0.1.0`）
    - 共有リポジトリが参照可能か（`gh repo view YuShimoji/shared-workflows`）
-2) 計画
+
+2. 計画
    - 完了済みの作業はスキップし、未着手/未完了のタスクのみを実行
    - 変更は Issue 起票 → ブランチ作成 → 小さくコミット → PR → CI 確認 → マージ
    - 変更は必ずファイルを直接編集し、コマンドはローカルで実行
    - PR は `gh` で作成、Squash Merge を既定
-4) セーフガード
+
+3. セーフガード
    - コンフリクトや手動解決が必要な場合は即時停止し、状況/推奨解を報告
 
 ## 参考
-  - テスト方針: `docs/TESTING.md`
-  - 利用手順: `docs/USAGE.md`
-  - 埋め込みSDK: `docs/EMBED_TESTING.md`
+
+- テスト方針: `docs/TESTING.md`
+- 利用手順: `docs/USAGE.md`
+- 埋め込みSDK: `docs/EMBED_TESTING.md`
 
 ## リスク/懸念
+
 - ルール適用の浸透（コントリビュータ周知）
 
 ## Backlog（将来提案）
 
-- Mission 10: DocFX によるドキュメントサイト構築（DocFX導入・CIでビルド・GitHub Pages公開・API/仕様の自動生成）
 - CONTRIBUTING.md に v1.1 へのリンク追加
-- PR テンプレートに「中断可能点」欄を標準化
 - dev-check に AI_CONTEXT.md の存在と最終更新日時の妥当性チェックを追加

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "content": [
+      {
+        "src": ".",
+        "files": [
+          "README.md",
+          "AI_CONTEXT.md"
+        ]
+      },
+      {
+        "src": "docs",
+        "files": [
+          "**/*.md",
+          "!test-reports/**"
+        ]
+      }
+    ],
+    "resource": [],
+    "dest": "_site",
+    "globalMetadata": {
+      "_appTitle": "Zen Writer Docs",
+      "_appFooter": "© 2025 Zen Writer Project",
+      "_enableSearch": true,
+      "language": "ja-JP"
+    },
+    "template": [
+      "default"
+    ]
+  }
+}

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -7,11 +7,31 @@
 - `index.html` をダブルクリックで開く（Windows/Mac共通）
 - オフラインでも動作します
 
-## GitHub Pages で公開
+## GitHub Pages で公開（DocFX サイト）
 
-1. GitHubに新規リポジトリを作成し、本フォルダの内容を push
-2. リポジトリ設定 → Pages → Branch を `main`/`master` の `root` に設定
-3. 数分後、`https://<your-account>.github.io/<repo-name>/` でアクセス可能
+DocFX によるドキュメントサイトは GitHub Actions で自動ビルドされ、`docs/` 以下のMarkdownと `README.md` などを対象に `_site/` を生成して公開します。
+
+### ローカルビルド手順
+
+1. 依存: [.NET 8 SDK](https://dotnet.microsoft.com/) と `docfx` ローカルツール（`dotnet tool restore`）。
+2. ルートで以下を実行。
+
+   ```bash
+   dotnet tool restore
+   dotnet docfx build
+   ```
+
+3. 出力: `_site/` 以下に静的ファイルが生成されます。`npx serve _site` 等で確認可能。
+
+### GitHub Pages 自動デプロイ
+
+1. `main` ブランチへ push すると `.github/workflows/deploy-pages.yml` が起動。
+2. ワークフローは `dotnet docfx build` を実行して `_site/` を生成し、`actions/deploy-pages@v4` で `github-pages` 環境へデプロイ。
+3. 公開URLはリポジトリの Pages 設定で確認できます（例: `https://<org>.github.io/WritingPage/`）。
+
+### 既存の `index.html` を公開したい場合
+
+DocFX サイトとは別に、エディタ本体を公開したい場合は従来どおり GitHub Pages の `root` へ静的ファイルを配置するか、別ブランチ/別リポジトリでホストしてください。
 
 ## Netlify で公開
 

--- a/docs/docfx_overview.md
+++ b/docs/docfx_overview.md
@@ -1,0 +1,14 @@
+# DocFX 概要とサイト構成
+
+このドキュメントは DocFX によるドキュメントサイト構築の概要をまとめます。
+
+- **ビルドコマンド**: `dotnet docfx build`
+- **出力先**: `_site/`
+- **トピック構成**はリポジトリ直下の `toc.yml` で制御。
+- **テンプレート**は DocFX デフォルト。
+- **検索機能**はデフォルト設定で有効化されています（`globalMetadata._enableSearch`）。
+
+## 参照
+
+- `docfx.json`
+- `.github/workflows/deploy-pages.yml`

--- a/toc.yml
+++ b/toc.yml
@@ -1,0 +1,72 @@
+- name: ホーム
+  href: README.md
+- name: AI コンテキスト
+  href: AI_CONTEXT.md
+- name: ガイド
+  items:
+    - name: 利用手順
+      href: docs/USAGE.md
+    - name: FAQ
+      href: docs/FAQ.md
+    - name: テーマ設定
+      href: docs/THEMES.md
+    - name: ガジェット
+      href: docs/GADGETS.md
+    - name: スナップショット
+      href: docs/SNAPSHOT_DESIGN.md
+- name: 開発プロトコル
+  items:
+    - name: 開発プロトコル
+      href: DEVELOPMENT_PROTOCOL.md
+    - name: DocFX概要
+      href: docs/docfx_overview.md
+    - name: ブランチ戦略
+      href: docs/BRANCHING.md
+    - name: コーディング規約
+      href: docs/CONVENTIONS.md
+    - name: ラベル運用
+      href: docs/LABELS.md
+    - name: ISSUE 運用
+      href: docs/ISSUES.md
+    - name: ROADMAP
+      href: docs/ROADMAP.md
+    - name: BACKLOG
+      href: docs/BACKLOG.md
+- name: 埋め込み/連携
+  items:
+    - name: Embed SDK
+      href: docs/EMBED_SDK.md
+    - name: Embed Testing
+      href: docs/EMBED_TESTING.md
+    - name: Embed セキュリティ
+      href: docs/KNOWN_ISSUES.md
+    - name: Choice Plugins
+      href: docs/choices-driven-development.md
+- name: デザイン資料
+  items:
+    - name: アプリ設計
+      href: docs/DESIGN.md
+    - name: デザインハブ
+      href: docs/DESIGN_HUB.md
+    - name: パレット設計
+      href: docs/PALETTE_DESIGN.md
+- name: テスト/運用
+  items:
+    - name: テスト方針
+      href: docs/TESTING.md
+    - name: デプロイ手順
+      href: docs/DEPLOY.md
+    - name: RELEASE ノート
+      href: docs/RELEASE.md
+    - name: Snapshot Reports
+      href: docs/test-reports/template.md
+- name: 付録
+  items:
+    - name: HUD/Editor 拡張
+      href: docs/EDITOR_EXTENSIONS.md
+    - name: Mission ルール
+      href: docs/Windsurf_AI_Collab_Rules_v1.1.md
+    - name: セキュリティポリシー
+      href: SECURITY.md
+    - name: 利用規約
+      href: CODE_OF_CONDUCT.md


### PR DESCRIPTION
## Summary
- DocFX をローカルツールとして導入し、docfx.json/	oc.yml でサイト構成を定義
- .github/workflows/deploy-pages.yml を DocFX ビルド→Pages デプロイ専用ワークフローへ更新
- docs/DEPLOY.md を DocFX サイトのビルド/公開手順で更新し、docs/docfx_overview.md を追加

## Testing
- dotnet docfx build